### PR TITLE
Added @types/tapable at version ^0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@types/redux-thunk": "^2.1.31",
     "@types/sinon": "^1.16.34",
     "@types/source-map": "^0.5.0",
+    "@types/tapable": "^0.2.5",
     "@types/three": "^0.84.15",
     "@types/uglify-js": "^2.6.28",
     "@types/webpack": "^2.2.2",


### PR DESCRIPTION
The build process fails due to `@types/webpack` pulling `@types/tapable` at version 1.0.0.

As per `@types/webpack`'s (2.2.16) package.json:

`"dependencies": {`
`  "@types/node": "*",`
`  "@types/tapable": "*",`
`  "@types/uglify-js": "*"`
`}`



This results in the errors:

`ERROR in [at-loader] ./node_modules/@types/webpack/index.d.ts:556:28`
`Type 'typeof "node_modules/@types/tapable/index"' is not a constructor function type.`

`ERROR in [at-loader] ./node_modules/@types/webpack/index.d.ts:598:46`
`Namespace '"node_modules/@types/tapable/index"' has no exported member 'Plugin'.`

`ERROR in [at-loader] ./node_modules/@types/webpack/index.d.ts:602:53`
`Namespace '"node_modules/@types/tapable/index"' has no exported member 'Plugin'.`

Specifying `@types/tapable` to ^0.2.5 in package.json solves the issue.